### PR TITLE
Refactor model architecture: extract backbone, activations, and configs into separate modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+# Concurrency group to cancel in-progress CI runs when pushing new commits to
+# the same branch/PR. Saves CI resources and gives faster feedback.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UV_VERSION: "0.9"
+
+jobs:
+  lint-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Run ruff linter
+        run: |
+          echo "Running ruff linter..."
+          uvx ruff check src/
+
+      - name: Run ruff formatter
+        run: |
+          echo "Running ruff formatter..."
+          uvx ruff format --check src/
+
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: Run type checker
+        run: |
+          echo "Running ty type checker..."
+          uv run ty check src/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+
+      - name: Run tests
+        run: |
+          echo "Running tests using pytest..."
+          uv run pytest -v --tb=short tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,14 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "pre-commit>=4.3.0",
+    "pytest>=9.0.1",
     "ruff>=0.14.3",
     "ty>=0.0.1a25",
+]
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::UserWarning:torch.autograd.graph",
 ]
 
 [tool.ty.rules]

--- a/src/pytorch_mdn/activations.py
+++ b/src/pytorch_mdn/activations.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import torch.nn as nn
+from torch import Tensor as TorchTensor
+
+ACTIVATION_FUNCTIONS = {
+    "relu": nn.ReLU,
+    "gelu": nn.GELU,
+    "mish": nn.Mish,
+    "silu": nn.SiLU,
+}
+
+
+class ElevatedELU(nn.ELU):
+    """ELU activation shifted upwards by 1 to get strictly positive outputs."""
+
+    def __init__(self):
+        super().__init__(alpha=1.0)
+
+    def forward(self, input: TorchTensor) -> TorchTensor:
+        return super().forward(input) + 1.0

--- a/src/pytorch_mdn/backbone.py
+++ b/src/pytorch_mdn/backbone.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import torch.nn as nn
+from torch import Tensor as TorchTensor
+
+from .activations import ACTIVATION_FUNCTIONS
+
+
+class MLPBackbone(nn.Module):
+    """Multi-layer perceptron backbone with configurable normalisation.
+
+    This class serves as a feature extractor, transforming inputs through
+    multiple hidden layers. It does not include an output layer, making it
+    suitable as a shared backbone for models with multiple output heads.
+
+    Parameters
+    ----------
+    input_dim : int
+        Dimension of input features.
+    hidden_dims : list[int]
+        List of hidden layer dimensions.
+    activation_type : str
+        Activation function name. Must be one of "relu", "gelu", "mish",
+        "silu".
+    norm_type : {"batch", "layer"} or None, default=None
+        Type of normalisation layer to use. "batch" for batch normalisation,
+        "layer" for layer normalisation, or None for no normalisation.
+    norm_after_act : bool, default=False
+        Whether to apply normalisation after activation functions. If False,
+        normalisation is applied before activation.
+    dropout_rate : float, default=0.0
+        Dropout probability for regularisation. Must be between 0.0 and 1.0.
+        No dropout is applied if 0.0.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dims: list[int],
+        activation_type: str,
+        norm_type: Literal["batch", "layer"] | None = None,
+        norm_after_act: bool = False,
+        dropout_rate: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.input_dim = input_dim
+        self.hidden_dims = hidden_dims
+        self.output_dim = hidden_dims[-1] if hidden_dims else input_dim
+
+        activation_fn = ACTIVATION_FUNCTIONS.get(activation_type.lower(), nn.GELU)
+
+        layers = []
+        prev_dim = input_dim
+        for hidden_dim in hidden_dims:
+            block = [nn.Linear(prev_dim, hidden_dim), activation_fn()]
+
+            if norm_type == "batch":
+                norm_layer = nn.BatchNorm1d(hidden_dim)
+            elif norm_type == "layer":
+                norm_layer = nn.LayerNorm(hidden_dim)
+            else:
+                norm_layer = None
+
+            if norm_layer is not None:
+                if norm_after_act:
+                    block.append(norm_layer)
+                else:
+                    block.insert(1, norm_layer)
+
+            if dropout_rate > 0.0:
+                block.append(nn.Dropout(dropout_rate))
+
+            layers.extend(block)
+            prev_dim = hidden_dim
+
+        self.layers = nn.Sequential(*layers)
+
+    def forward(self, x: TorchTensor) -> TorchTensor:
+        """Forward pass through the MLP backbone.
+
+        Parameters
+        ----------
+        x : Tensor of shape (batch_size, input_dim)
+            Input tensor.
+
+        Returns
+        -------
+        output : Tensor of shape (batch_size, output_dim)
+            Output features after passing through all hidden layers.
+            `output_dim` is equal to the last element in `hidden_dims`.
+        """
+        return self.layers(x)

--- a/src/pytorch_mdn/configs.py
+++ b/src/pytorch_mdn/configs.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    from .mixup import BaseMixup, KDEMixup, RandomMixup
+    from .model import MixtureDensityNetwork
+
+
+class MDNConfig(BaseModel, extra="forbid"):
+    """Configuration for MDN model architecture."""
+
+    input_dim: int = Field(..., gt=0, description="Dimension of input features")
+    hidden_dims: list[int] = Field(..., description="Hidden layer dimensions")
+    output_dim: int = Field(..., gt=0, description="Dimension of output targets")
+    n_components: int = Field(..., gt=0, description="Number of mixture components")
+    activation_type: str = Field(..., description="Activation function name")
+    norm_type: Literal["batch", "layer"] | None = Field(
+        None, description="Type of normalisation layer to use"
+    )
+    norm_after_act: bool = Field(
+        False, description="Whether to apply normalisation after activation"
+    )
+    dropout_rate: float = Field(
+        0.0, ge=0.0, le=1.0, description="Dropout rate for regularisation"
+    )
+
+    @field_validator("hidden_dims", mode="before")
+    @classmethod
+    def ensure_hidden_dims_list(cls, v: list[int] | int) -> list[int]:
+        """Ensure `hidden_dims` is always a list of integers."""
+        if isinstance(v, int):
+            return [v]
+        return v
+
+    def create_model(self) -> MixtureDensityNetwork:
+        """Create Mixture Density Network model based on the configuration."""
+        from .model import MixtureDensityNetwork
+
+        return MixtureDensityNetwork(
+            input_dim=self.input_dim,
+            hidden_dims=self.hidden_dims,
+            output_dim=self.output_dim,
+            n_components=self.n_components,
+            activation_type=self.activation_type,
+            norm_type=self.norm_type,
+            norm_after_act=self.norm_after_act,
+            dropout_rate=self.dropout_rate,
+        )
+
+
+class BaseMixupConfig(BaseModel, ABC):
+    """Base class for all MixUp configurations."""
+
+    @abstractmethod
+    def create_mixup(self) -> BaseMixup:
+        """Convert configuration to MixUp instance.
+
+        Returns
+        -------
+        BaseMixup
+            MixUp instance created from this configuration.
+        """
+        ...
+
+
+class RandomMixupConfig(BaseMixupConfig, extra="forbid"):
+    """Configuration for random MixUp augmentation."""
+
+    type: Literal["random"] = "random"
+    alpha: float = Field(
+        ..., gt=0, description="Beta-distribution parameter for lambda sampling"
+    )
+    seed: int | None = Field(
+        default=None, description="Random seed for reproducibility"
+    )
+
+    def create_mixup(self) -> RandomMixup:
+        """Convert configuration to RandomMixup instance."""
+        from .mixup import RandomMixup
+
+        return RandomMixup(alpha=self.alpha, seed=self.seed)
+
+
+class KDEMixupConfig(BaseMixupConfig, extra="forbid"):
+    """Configuration for KDE-based MixUp augmentation.
+
+    Uses kernel density estimation to find similar samples in *target space*.
+    """
+
+    type: Literal["kde"] = "kde"
+    bandwidth: float = Field(..., description="Kernel bandwidth")
+    kernel: Literal["gaussian", "tophat", "epanechnikov"] = Field(
+        default="gaussian", description="Kernel type to use"
+    )
+    metric: Literal["euclidean", "cosine", "manhattan"] = Field(
+        default="euclidean", description="Metric to use for distance computation"
+    )
+    alpha: float = Field(
+        ..., gt=0, description="Beta-distribution parameter for lambda sampling"
+    )
+    seed: int | None = Field(
+        default=None, description="Random seed for reproducibility"
+    )
+
+    def create_mixup(self) -> KDEMixup:
+        """Convert configuration to KDEMixup instance."""
+        from .mixup import KDEMixup
+
+        return KDEMixup(
+            bandwidth=self.bandwidth,
+            alpha=self.alpha,
+            kernel=self.kernel,
+            metric=self.metric,
+            seed=self.seed,
+        )
+
+
+# Union type for all mixup configs
+MixupConfig = RandomMixupConfig | KDEMixupConfig

--- a/src/pytorch_mdn/lit_module.py
+++ b/src/pytorch_mdn/lit_module.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
 
     from torch import Tensor as TorchTensor
 
-    from .mixup import MixupConfig
-    from .model import MDNConfig
+    from .configs import MDNConfig, MixupConfig
 
 
 class MDNLitModule(LightningModule):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test configuration for pytest."""

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -1,0 +1,176 @@
+"""Tests for activation functions and classes."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pytorch_mdn.activations import ElevatedELU
+
+
+class TestElevatedELU:
+    """Tests for ElevatedELU activation function."""
+
+    @pytest.fixture
+    def activation(self):
+        """Fixture providing an ElevatedELU instance for tests."""
+        return ElevatedELU()
+
+    def test_initialization(self, activation):
+        """Test that ElevatedELU initialises with alpha=1.0."""
+        assert activation.alpha == 1.0
+
+    @pytest.mark.parametrize(
+        ("input_values", "expected_values"),
+        [
+            # Positive inputs: ELU(x) = x, so ElevatedELU(x) = x + 1
+            ([1.0, 2.0, 3.0, 5.0], [2.0, 3.0, 4.0, 6.0]),  # x > 0 -> Act = x + 1
+            ([0.0], [1.0]),  # x = 0 -> Act = 1
+            ([1.5], [2.5]),
+        ],
+    )
+    def test_positive_and_zero_inputs(self, activation, input_values, expected_values):
+        """Test ElevatedELU with positive and zero inputs.
+
+        For x >= 0, ELU(x) = x, so ElevatedELU(x) = x + 1.
+        """
+        x = torch.tensor(input_values)
+        expected = torch.tensor(expected_values)
+
+        output = activation(x)
+
+        assert torch.allclose(output, expected)
+
+    @pytest.mark.parametrize(
+        "input_values", [[-1.0, -2.0, -0.5], [-0.1], [-5.0, -3.5, -1.2]]
+    )
+    def test_negative_inputs(self, activation, input_values):
+        """Test ElevatedELU with negative inputs.
+
+        For negative inputs, ELU(x) = alpha * (exp(x) - 1).
+        With alpha=1.0, ELU(x) = exp(x) - 1.
+        So ElevatedELU(x) = exp(x) - 1 + 1 = exp(x).
+        """
+        x = torch.tensor(input_values)
+        expected = torch.exp(x)
+        output = activation(x)
+        assert torch.allclose(output, expected, rtol=1e-5)
+
+    def test_mixed_inputs(self, activation):
+        """Test ElevatedELU with mixed positive and negative inputs."""
+        x = torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0])
+
+        # Expected: [exp(-2), exp(-1), 1, 2, 3]
+        expected = torch.tensor(
+            [
+                torch.exp(torch.tensor(-2.0)).item(),
+                torch.exp(torch.tensor(-1.0)).item(),
+                1.0,
+                2.0,
+                3.0,
+            ]
+        )
+        output = activation(x)
+        assert torch.allclose(output, expected, rtol=1e-5)
+
+    def test_strictly_positive_output(self, activation):
+        """Test that ElevatedELU always produces strictly positive outputs.
+
+        This is the key property: all outputs should be > 0.
+        """
+        # Test with a wide range of inputs
+        x = torch.linspace(-10, 10, 100)
+        output = activation(x)
+        assert torch.all(output > 0)
+
+    def test_minimum_output_value(self, activation):
+        """Test that the minimum output approaches 0 as input → -∞.
+
+        For very negative inputs, ElevatedELU(x) = exp(x) → 0.
+        Due to floating point precision, extremely negative values may
+        underflow to exactly 0, but moderately negative values should be
+        close to 0 but positive.
+        """
+        # Moderately negative input (not so extreme to cause underflow)
+        x = torch.tensor([-10.0])
+        output = activation(x)
+
+        # Should be very close to 0 but positive
+        assert output > 0
+        assert output < 0.01
+
+    def test_batch_processing(self, activation):
+        """Test ElevatedELU with batched inputs."""
+        # 2D tensor with batch_size=3, n_features=4
+        x = torch.tensor(
+            [[-1.0, 0.0, 1.0, 2.0], [-2.0, -0.5, 0.5, 1.5], [0.0, 1.0, 2.0, 3.0]]
+        )
+
+        output = activation(x)
+
+        assert output.shape == x.shape
+        assert torch.all(output > 0)
+
+    def test_gradient_flow(self, activation):
+        """Test that gradients flow correctly through ElevatedELU."""
+        x = torch.tensor([1.0, -1.0, 0.0], requires_grad=True)
+        output = activation(x)
+        loss = output.sum()
+        loss.backward()
+
+        # Gradients should exist and be non-zero
+        assert x.grad is not None
+        assert not torch.all(x.grad == 0)
+
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+    def test_output_dtype_preservation(self, activation, dtype):
+        """Test that ElevatedELU preserves input dtype."""
+        x = torch.tensor([1.0, -1.0], dtype=dtype)
+        output = activation(x)
+        assert output.dtype == dtype
+
+    def test_device_compatibility(self, activation):
+        """Test that ElevatedELU works on different devices."""
+        # CPU
+        x_cpu = torch.tensor([1.0, -1.0, 0.0])
+        output_cpu = activation(x_cpu)
+        assert output_cpu.device.type == "cpu"
+        assert torch.all(output_cpu > 0)
+
+        # GPU (if available)
+        if torch.cuda.is_available():
+            x_cuda = x_cpu.cuda()
+            activation_cuda = ElevatedELU().cuda()
+            output_cuda = activation_cuda(x_cuda)
+            assert output_cuda.device.type == "cuda"
+            assert torch.all(output_cuda > 0)
+
+    @pytest.mark.parametrize(
+        ("x_value", "expected_value", "tolerance"),
+        [
+            (-1e-6, 1.0, 1e-5),  # Left of zero
+            (0.0, 1.0, 1e-7),  # At zero
+            (1e-6, 1.0, 1e-5),  # Right of zero
+        ],
+    )
+    def test_continuity_at_zero(self, activation, x_value, expected_value, tolerance):
+        """Test that ElevatedELU is continuous at x=0.
+
+        The function should be continuous, especially at x=0 where ELU
+        transitions from exponential to linear.
+        """
+        x = torch.tensor([x_value])
+        y = activation(x)
+
+        assert torch.allclose(y, torch.tensor([expected_value]), atol=tolerance)
+
+    def test_comparison_with_manual_computation(self, activation):
+        """Test against manual computation of ElevatedELU."""
+        x = torch.tensor([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
+
+        elu_output = torch.where(x > 0, x, 1.0 * (torch.exp(x) - 1))  # alpha=1.0
+        expected = elu_output + 1.0
+
+        output = activation(x)
+
+        assert torch.allclose(output, expected, rtol=1e-5)

--- a/uv.lock
+++ b/uv.lock
@@ -372,6 +372,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -849,6 +858,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.35.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1028,6 +1046,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload-time = "2025-11-12T13:05:09.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload-time = "2025-11-12T13:05:07.379Z" },
+]
+
+[[package]]
 name = "pytorch-lightning"
 version = "2.5.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1063,6 +1106,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1081,6 +1125,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest", specifier = ">=9.0.1" },
     { name = "ruff", specifier = ">=0.14.3" },
     { name = "ty", specifier = ">=0.0.1a25" },
 ]


### PR DESCRIPTION
## Summary
Refactor the MDN codebase to improve modularity and maintainability by separating concerns into dedicated modules:

- Extract activation functions into `activations.py`.
- Create reusable MLP backbone in `backbone.py`.
- Consolidate all Pydantic configuration classes in `configs.py`.
- Enhance MDN with new features: layer normalisation and dropout support.

## Motivation
The previous `model.py` was becoming monolithic, containing model implementation, configuration classes, and utility components. This restructuring:

- Improves separation of concerns: each module has a single, clear responsibility.
- Enhances reusability: `MLPBackbone` can be reused across different model architectures.
- Better organisation: all configuration classes are centralised in one location.
- Facilitates testing: smaller, focused modules are easier to test independently.
- Adds flexibility: new normalisation and dropout options for better model regularisation.